### PR TITLE
Remove repositories option to orchestra/phpseclib fork since phpseclib v0.3.7 already solved function autoloading at their end.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,5 @@
         "psr-0": {
             "Indatus\\Dispatcher\\": "src/"
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git://github.com/orchestral/phpseclib.git"
-        }
-    ]
+    }
 }


### PR DESCRIPTION
Signed-off-by: crynobone crynobone@gmail.com
