### PR TITLE
PHP_BINARY is now used in command generation

### DIFF
--- a/src/Indatus/Dispatcher/Services/CommandService.php
+++ b/src/Indatus/Dispatcher/Services/CommandService.php
@@ -171,22 +171,11 @@ class CommandService
         /** @var \Indatus\Dispatcher\Platform $platform */
         $platform = App::make('Indatus\Dispatcher\Platform');
 
-        //load executable path
-        $executablePath = Config::get('dispatcher::executable');
-        if (!is_null($executablePath)) {
-            $commandPieces = [$executablePath];
+        $commandPieces = [];
+        if ($platform->isHHVM()) {
+            $commandPieces[] = '/usr/bin/env hhvm';
         } else {
-            $commandPieces = [];
-
-            if ($platform->isUnix()) {
-                $commandPieces[] = '/usr/bin/env';
-            }
-
-            if ($platform->isHHVM()) {
-                $commandPieces[] = 'hhvm';
-            } else {
-                $commandPieces[] = 'php';
-            }
+            $commandPieces[] = PHP_BINARY;
         }
 
         $commandPieces[] = base_path().'/artisan';

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -9,12 +9,5 @@
      *                      Scheduler and SchedulerService classes.
      *
      */
-    'driver' => 'cron',
-
-    /**
-     * Customize the path to your PHP executable.  If null, Dispatcher
-     * detects whether you're running HHVM or standard PHP and builds the
-     * executable path accordingly.
-     */
-    'executable' => null
+    'driver' => 'cron'
 ];

--- a/tests/Services/TestCommandService.php
+++ b/tests/Services/TestCommandService.php
@@ -279,8 +279,7 @@ class TestCommandService extends TestCase
         $scheduledCommand->shouldReceive('getName')->andReturn($commandName);
         $scheduledCommand->shouldReceive('user')->andReturn(false);
         $this->assertEquals($this->commandService->getRunCommand($scheduledCommand), implode(' ', array(
-                    '/usr/bin/env',
-                    'php',
+                    PHP_BINARY,
                     base_path().'/artisan',
                     $commandName,
                     '> /dev/null',
@@ -303,32 +302,10 @@ class TestCommandService extends TestCase
         $this->assertEquals($this->commandService->getRunCommand($scheduledCommand), implode(' ', array(
                     'START',
                     '/B',
-                    'php',
+                    PHP_BINARY,
                     base_path().'/artisan',
                     $commandName,
                     '> NULL'
-                )));
-    }
-
-    public function testGetRunCommandExecutable()
-    {
-        $executablePath = '/path/to/executable';
-        Config::shouldReceive('get')->with('dispatcher::executable')->andReturn($executablePath);
-        $this->app->instance('Indatus\Dispatcher\Platform', m::mock('Indatus\Dispatcher\Platform', function ($m) {
-                    $m->shouldReceive('isUnix')->andReturn(true);
-                    $m->shouldReceive('isWindows')->andReturn(false);
-                }));
-
-        $commandName = 'test:command';
-        $scheduledCommand = $this->mockCommand();
-        $scheduledCommand->shouldReceive('getName')->andReturn($commandName);
-        $scheduledCommand->shouldReceive('user')->andReturn(false);
-        $this->assertEquals($this->commandService->getRunCommand($scheduledCommand), implode(' ', array(
-                    $executablePath,
-                    base_path().'/artisan',
-                    $commandName,
-                    '> /dev/null',
-                    '&'
                 )));
     }
 
@@ -368,8 +345,7 @@ class TestCommandService extends TestCase
                 )
             ),
             implode(' ', array(
-                    '/usr/bin/env',
-                    'php',
+                    PHP_BINARY,
                     base_path().'/artisan',
                     $commandName,
                     'option',
@@ -394,8 +370,7 @@ class TestCommandService extends TestCase
                 )
             ),
             implode(' ', array(
-                    '/usr/bin/env',
-                    'php',
+                    PHP_BINARY,
                     base_path().'/artisan',
                     $commandName,
                     '--option="value"',
@@ -414,8 +389,7 @@ class TestCommandService extends TestCase
         $scheduledCommand->shouldReceive('user')->andReturn($user);
         $this->assertEquals($this->commandService->getRunCommand($scheduledCommand), implode(' ', array(
                     'sudo -u '.$user,
-                    '/usr/bin/env',
-                    'php',
+                    PHP_BINARY,
                     base_path().'/artisan',
                     $commandName,
                     '> /dev/null',


### PR DESCRIPTION
PHP 5.4's `PHP_BINARY` constant is now used and the `executable` config option has been removed
